### PR TITLE
Add dashboard panel with charts and fix transactions table

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "recharts": "^2.8.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.3.1",


### PR DESCRIPTION
## Summary
- fix transaction table so header and rows align within a single scrollable table
- add dashboard tab with KPIs, monthly income/expense line chart and expense category pie chart
- expose derived monthly stats and category totals and add recharts dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68a18033ee14832f83dbfd7ae229b74b