### PR TITLE
feat: add dashboard analytics and budgeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# Canvas Finance Tracker
+
+This demo app keeps all data in localStorage.
+
+## Budgets
+Monthly budgets are stored in `cft_budgets_v1`. Each record contains a planned amount for an expense category. The dashboard shows the plan, actual expenses derived from transactions, and the difference (Plan − Actual).

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from "recharts";
+import Dashboard from "./Dashboard";
 
 // =============================================================
 // Canvas Finance Tracker — v1.1 (senior refactor: structure + perf)
@@ -243,7 +243,6 @@ export default function App() {
           {[
             { id: "dashboard", label: "Dashboard" },
             { id: "transactions", label: "Transactions" },
-            { id: "items", label: "Items" },
             { id: "wallets", label: "Wallets" },
           ].map(t => (
             <button
@@ -254,15 +253,10 @@ export default function App() {
           ))}
         </nav>
 
-        {tab === "dashboard" && (
-          <DashboardPanel
-            monthly={monthly}
-            expenseByItem={expenseByItem}
-            totals={totals}
-            net={netThisMonth}
-            ratio={expenseIncomeRatio}
-          />
-        )}
+          {tab === "dashboard" && (
+            <Dashboard txs={db.txs} items={db.items} totals={totals} />
+          )}
+
 
         {tab !== "dashboard" && <SummaryRow totals={totals} />}
 
@@ -316,43 +310,7 @@ function SummaryRow({ totals }) {
   );
 }
 
-function DashboardPanel({ monthly, expenseByItem, totals, net, ratio }) {
-  const COLORS = ["#3b82f6", "#ef4444", "#f97316", "#10b981", "#8b5cf6", "#6366f1", "#14b8a6", "#f59e0b"]; // tailwind colors
-  return (
-    <div className="space-y-6 mb-6">
-      <div className="grid md:grid-cols-3 gap-3">
-        <KPI title="Balance" value={formatMoney(totals.totalBalance)} positive />
-        <KPI title="Net this month" value={formatMoney(net)} positive={net>=0} />
-        <KPI title="Exp/Inc ratio" value={formatPercent(ratio)} />
-      </div>
-      <div className="grid md:grid-cols-2 gap-6">
-        <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
-            <LineChart data={monthly}>
-              <XAxis dataKey="month" />
-              <YAxis />
-              <Tooltip formatter={(v) => formatMoney(v)} />
-              <Line type="monotone" dataKey="income" stroke="#16a34a" name="Income" />
-              <Line type="monotone" dataKey="expense" stroke="#dc2626" name="Expenses" />
-            </LineChart>
-          </ResponsiveContainer>
-        </div>
-        <div className="h-64">
-          <ResponsiveContainer width="100%" height="100%">
-            <PieChart>
-              <Pie data={expenseByItem} dataKey="value" nameKey="name" label>
-                {expenseByItem.map((entry, index) => (
-                  <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                ))}
-              </Pie>
-              <Tooltip formatter={(v) => formatMoney(v)} />
-            </PieChart>
-          </ResponsiveContainer>
-        </div>
-      </div>
-    </div>
-  );
-}
+// function DashboardPanel removed for new Dashboard
 
 // ------------------------- Transactions -------------------------
 function TransactionsPanel({ txs, items, wallets, addTx, updTx, delTx, itemMap, walletMap, search, setSearch }) {

--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -1,0 +1,150 @@
+import React, { useMemo, useState } from 'react';
+import {
+  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer,
+  PieChart, Pie, Cell, Legend, CartesianGrid
+} from 'recharts';
+import { buildMonthlySeries, buildExpenseStructure, buildBudgetReport } from './analytics';
+import { fmtInt, fmtCurrency2 } from './format';
+import { useBudgets } from './budgets';
+
+const COLORS = ['#10B981','#F43F5E','#3B82F6','#F59E0B','#6366F1','#14B8A6','#8B5CF6','#F97316'];
+const colorFor = (name) => {
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) hash = (hash * 31 + name.charCodeAt(i)) >>> 0;
+  return COLORS[hash % COLORS.length];
+};
+
+const KPI = ({ title, value, positive }) => (
+  <div className={`rounded-2xl border bg-white p-4 shadow-sm ${positive===false?'':'text-gray-900'}`}>
+    <div className="text-xs uppercase tracking-wide text-gray-500">{title}</div>
+    <div className={`mt-1 text-2xl font-semibold ${positive ? 'text-emerald-600':'text-gray-900'}`}>{value}</div>
+  </div>
+);
+
+export default function Dashboard({ txs, items, totals }) {
+  const monthly = useMemo(() => buildMonthlySeries(txs), [txs]);
+  const expenseStructure = useMemo(() => buildExpenseStructure(txs, items), [txs, items]);
+
+  const { budgets, upsertBudget, deleteBudget } = useBudgets();
+  const [month, setMonth] = useState(new Date().toISOString().slice(0,7));
+  const budgetData = useMemo(() => buildBudgetReport(txs, items, budgets, month), [txs, items, budgets, month]);
+  const budgetIdMap = useMemo(() => {
+    const m = new Map();
+    budgets.forEach(b => { if (b.period===month) m.set(b.itemId, b.id); });
+    return m;
+  }, [budgets, month]);
+  const expenseItems = useMemo(() => items.filter(i=>i.type==='expense'), [items]);
+  const unusedItems = expenseItems.filter(i => !budgetData.rows.find(r=>r.itemId===i.id));
+  const [newItem, setNewItem] = useState(unusedItems[0]?.id || '');
+  const [newAmount, setNewAmount] = useState('');
+
+  const addBudget = () => {
+    const amount = parseFloat(newAmount);
+    if (!newItem || isNaN(amount)) return;
+    upsertBudget({ itemId:newItem, period:month, amount });
+    setNewAmount('');
+  };
+
+  const onBudgetChange = (itemId, val) => {
+    const amount = parseFloat(val);
+    if (isNaN(amount) || amount < 0) return;
+    const id = budgetIdMap.get(itemId);
+    upsertBudget({ id, itemId, period:month, amount });
+  };
+
+  return (
+    <div className="space-y-6 mb-6">
+      <div className="grid md:grid-cols-4 gap-3">
+        <KPI title="Income" value={fmtInt(totals.income)} positive />
+        <KPI title="Expenses" value={fmtInt(totals.expense)} />
+        <KPI title="Net" value={fmtInt(totals.net)} positive={totals.net>=0} />
+        <KPI title="Total Balance" value={fmtInt(totals.totalBalance)} positive />
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="h-[340px]" aria-label="Monthly Income vs Expenses">
+          {monthly.length === 0 ? (
+            <div className="h-full flex items-center justify-center text-gray-500">No data yet.</div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={monthly}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="label" />
+                <YAxis tickFormatter={(v)=>fmtInt(v)} />
+                <Tooltip formatter={(v)=>fmtInt(v)} />
+                <Legend />
+                <Line type="monotone" dataKey="income" name="Income" stroke="#10B981" dot={false} strokeWidth={2} />
+                <Line type="monotone" dataKey="expense" name="Expense" stroke="#F43F5E" dot={false} strokeWidth={2} />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+        <div className="h-[340px]" aria-label="Expense Structure">
+          {expenseStructure.length === 0 ? (
+            <div className="h-full flex items-center justify-center text-gray-500">No data yet.</div>
+          ) : (
+            <ResponsiveContainer width="100%" height="100%">
+              <PieChart>
+                <Pie data={expenseStructure} dataKey="share" nameKey="item" label={({item,share})=>`${item} — ${share}%`}>
+                  {expenseStructure.map(e => <Cell key={e.item} fill={colorFor(e.item)} />)}
+                </Pie>
+                <Tooltip formatter={(v, name, props)=>fmtInt(props.payload.amount)} />
+              </PieChart>
+            </ResponsiveContainer>
+          )}
+        </div>
+      </div>
+
+      <div className="rounded-2xl border bg-white p-4 shadow-sm">
+        <div className="flex items-center justify-between mb-4">
+          <h3 className="font-semibold">Budgets</h3>
+          <input type="month" value={month} onChange={e=>setMonth(e.target.value)} className="border rounded-xl px-2 py-1" />
+        </div>
+        <div className="overflow-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left border-b">
+                <th className="py-1">Category</th>
+                <th className="py-1 text-right">Budget</th>
+                <th className="py-1 text-right">Actual</th>
+                <th className="py-1 text-right">Difference</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              {budgetData.rows.map(r => (
+                <tr key={r.itemId} className="border-b last:border-b-0">
+                  <td className="py-1">{r.itemName}</td>
+                  <td className="py-1 text-right"><input type="number" step="0.01" value={r.budget} onChange={e=>onBudgetChange(r.itemId,e.target.value)} className="w-24 border rounded px-1 text-right"/></td>
+                  <td className="py-1 text-right">{fmtCurrency2(r.actual)}</td>
+                  <td className={`py-1 text-right ${r.difference>=0?'text-emerald-600':'text-rose-600'}`}>{fmtCurrency2(r.difference)}</td>
+                  <td className="py-1 text-right"><button onClick={()=>deleteBudget(budgetIdMap.get(r.itemId))} className="text-xs text-rose-600">Del</button></td>
+                </tr>
+              ))}
+              <tr>
+                <td className="py-1">
+                  <select value={newItem} onChange={e=>setNewItem(e.target.value)} className="border rounded px-1">
+                    {unusedItems.map(i=>(<option key={i.id} value={i.id}>{i.name}</option>))}
+                  </select>
+                </td>
+                <td className="py-1 text-right"><input type="number" step="0.01" value={newAmount} onChange={e=>setNewAmount(e.target.value)} className="w-24 border rounded px-1 text-right"/></td>
+                <td className="py-1 text-right">—</td>
+                <td className="py-1 text-right">—</td>
+                <td className="py-1 text-right"><button onClick={addBudget} className="text-xs text-emerald-600">Add</button></td>
+              </tr>
+            </tbody>
+            <tfoot>
+              <tr className="font-semibold border-t">
+                <td className="py-1">Totals</td>
+                <td className="py-1 text-right">{fmtCurrency2(budgetData.totals.budget)}</td>
+                <td className="py-1 text-right">{fmtCurrency2(budgetData.totals.actual)}</td>
+                <td className={`py-1 text-right ${budgetData.totals.difference>=0?'text-emerald-600':'text-rose-600'}`}>{fmtCurrency2(budgetData.totals.difference)}</td>
+                <td></td>
+              </tr>
+            </tfoot>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/analytics.js
+++ b/src/analytics.js
@@ -1,0 +1,83 @@
+import { fmtMonthLabel } from './format';
+
+// Tx, Item, BudgetRecord types come from App context
+
+export function buildMonthlySeries(txs, from, to) {
+  const start = from ? new Date(from) : new Date(new Date().getFullYear(), 0, 1);
+  const end = to ? new Date(to) : new Date();
+  const m = new Map();
+  for (const t of txs) {
+    const d = new Date(t.date);
+    if (d < start || d > end) continue;
+    const key = t.date.slice(0, 7);
+    const obj = m.get(key) || { monthKey: key, label: fmtMonthLabel(key), income: 0, expense: 0 };
+    if (t.type === 'income') obj.income += t.amount; else obj.expense += t.amount;
+    m.set(key, obj);
+  }
+  return Array.from(m.values()).sort((a,b)=>a.monthKey.localeCompare(b.monthKey)).map(p=>({
+    ...p,
+    income: Math.round(p.income),
+    expense: Math.round(p.expense)
+  }));
+}
+
+export function buildExpenseStructure(txs, items, from, to) {
+  const start = from ? new Date(from) : new Date(new Date().getFullYear(), 0, 1);
+  const end = to ? new Date(to) : new Date();
+  const itemMap = new Map(items.map(i=>[i.id, i.name]));
+  const m = new Map();
+  for (const t of txs) {
+    if (t.type !== 'expense') continue;
+    const d = new Date(t.date);
+    if (d < start || d > end) continue;
+    const name = itemMap.get(t.itemId) || 'Unknown';
+    m.set(name, (m.get(name) || 0) + t.amount);
+  }
+  const total = Array.from(m.values()).reduce((s,v)=>s+v,0);
+  if (!total) return [];
+  return Array.from(m.entries()).map(([item, amount])=>({
+    item,
+    amount,
+    share: Math.round(amount/total*100)
+  }));
+}
+
+export function buildBudgetReport(txs, items, budgets, period) {
+  const itemMap = new Map(items.map(i=>[i.id, i.name]));
+  const actualMap = new Map();
+  const [y,m] = period.split('-').map(Number);
+  const from = new Date(y, m-1, 1);
+  const to = new Date(y, m, 0); // end of month
+  for (const t of txs) {
+    if (t.type !== 'expense') continue;
+    const d = new Date(t.date);
+    if (d < from || d > to) continue;
+    actualMap.set(t.itemId, (actualMap.get(t.itemId)||0)+t.amount);
+  }
+  const rowsMap = new Map();
+  for (const b of budgets) {
+    if (b.period !== period) continue;
+    rowsMap.set(b.itemId, { itemId:b.itemId, itemName:itemMap.get(b.itemId)||'Unknown', budget:b.amount, actual:0 });
+  }
+  for (const [itemId, actual] of actualMap) {
+    const row = rowsMap.get(itemId) || { itemId, itemName:itemMap.get(itemId)||'Unknown', budget:0, actual:0 };
+    row.actual = actual;
+    rowsMap.set(itemId, row);
+  }
+  const rows = Array.from(rowsMap.values()).map(r=>({
+    ...r,
+    budget: Number(r.budget.toFixed(2)),
+    actual: Number((r.actual||0).toFixed(2)),
+    difference: Number((r.budget - (r.actual||0)).toFixed(2))
+  })).filter(r=>r.budget>0 || r.actual>0);
+  const totals = rows.reduce((acc,r)=>{
+    acc.budget += r.budget;
+    acc.actual += r.actual;
+    acc.difference += r.difference;
+    return acc;
+  },{budget:0,actual:0,difference:0});
+  totals.budget = Number(totals.budget.toFixed(2));
+  totals.actual = Number(totals.actual.toFixed(2));
+  totals.difference = Number(totals.difference.toFixed(2));
+  return { rows, totals };
+}

--- a/src/budgets.js
+++ b/src/budgets.js
@@ -1,0 +1,43 @@
+import React from "react";
+const BUDGET_KEY = 'cft_budgets_v1';
+const VERSION = 1;
+
+const uid = () => Math.random().toString(36).slice(2) + Date.now().toString(36);
+
+function loadBudgets() {
+  try {
+    const raw = localStorage.getItem(BUDGET_KEY);
+    if (!raw) return { version: VERSION, budgets: [] };
+    const db = JSON.parse(raw);
+    if (db && db.version === VERSION && Array.isArray(db.budgets)) return db;
+  } catch {}
+  return { version: VERSION, budgets: [] };
+}
+
+function saveBudgets(db) {
+  localStorage.setItem(BUDGET_KEY, JSON.stringify(db));
+}
+
+export function useBudgets() {
+  const [db, setDb] = React.useState(() => loadBudgets());
+
+  React.useEffect(() => { saveBudgets(db); }, [db]);
+
+  const upsertBudget = React.useCallback((rec) => {
+    setDb(d => {
+      const budgets = d.budgets.filter(b => !(b.itemId === rec.itemId && b.period === rec.period));
+      const id = rec.id || uid();
+      return { ...d, budgets: [...budgets, { ...rec, id }] };
+    });
+  }, []);
+
+  const deleteBudget = React.useCallback((id) => {
+    setDb(d => ({ ...d, budgets: d.budgets.filter(b => b.id !== id) }));
+  }, []);
+
+  const listBudgets = React.useCallback((period) => {
+    return db.budgets.filter(b => b.period === period);
+  }, [db]);
+
+  return { budgets: db.budgets, upsertBudget, deleteBudget, listBudgets };
+}

--- a/src/format.js
+++ b/src/format.js
@@ -1,0 +1,19 @@
+export const fmtInt = (n, currency) =>
+  new Intl.NumberFormat(undefined, {
+    ...(currency ? { style: 'currency', currency } : {}),
+    maximumFractionDigits: 0
+  }).format(Math.round(n));
+
+export const fmtCurrency2 = (n, currency) =>
+  new Intl.NumberFormat(undefined, {
+    style: 'currency',
+    currency: currency || 'RUB',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2
+  }).format(n);
+
+export const fmtMonthLabel = (ym) => {
+  const [y, m] = ym.split('-').map(Number);
+  return new Intl.DateTimeFormat('en-US', { month: 'long', year: 'numeric' })
+    .format(new Date(y, m - 1, 1));
+};


### PR DESCRIPTION
## Summary
- add reusable formatters for integers, currency and months
- support budgets with a new useBudgets hook and analytics helpers
- introduce a dashboard with charts, KPIs and editable monthly budgets

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu')*

------
https://chatgpt.com/codex/tasks/task_e_68a196151310832f8bc5e3e191ca284a