### PR TITLE
Improve dashboard chart visuals

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -362,6 +362,7 @@ export default function App() {
           {tab === "dashboard" && (
             <Dashboard
               items={db.items}
+              txs={db.txs}
               totals={totals}
               monthly={monthly}
               budgets={db.budgets}

--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -1,9 +1,10 @@
 import React, { useMemo, useState } from 'react';
 import {
-  LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer,
+  LineChart, Line, Area, XAxis, YAxis, Tooltip, ResponsiveContainer,
   PieChart, Pie, Cell, Legend, CartesianGrid
 } from 'recharts';
 import { fmtInt, fmtMonthLabel } from './format';
+import { buildExpenseStructure } from './analytics';
 
 const COLORS = ['#10B981','#F43F5E','#3B82F6','#F59E0B','#6366F1','#14B8A6','#8B5CF6','#F97316'];
 const colorFor = (name) => {
@@ -19,7 +20,7 @@ const KPI = ({ title, value, positive }) => (
   </div>
 );
 
-export default function Dashboard({ items, totals, monthly, upsertBudget, actualByTopLevelForMonth, budgetByTopLevelForMonth }) {
+export default function Dashboard({ items, txs, totals, monthly, upsertBudget, actualByTopLevelForMonth, budgetByTopLevelForMonth }) {
   const [month, setMonth] = useState(new Date().toISOString().slice(0,7));
 
   const monthlySeries = useMemo(() => monthly.map(m => ({
@@ -28,16 +29,7 @@ export default function Dashboard({ items, totals, monthly, upsertBudget, actual
     expense: Math.round(m.expense),
   })), [monthly]);
 
-  const expenseStructure = useMemo(() => {
-    const arr = actualByTopLevelForMonth(month).filter(r => r.type === 'expense');
-    const total = arr.reduce((s, r) => s + r.amount, 0);
-    if (!total) return [];
-    return arr.map(r => ({
-      item: items.find(i => i.id === r.itemId)?.name || 'Unknown',
-      amount: Math.round(r.amount),
-      share: Math.round(r.amount / total * 100)
-    }));
-  }, [actualByTopLevelForMonth, month, items]);
+  const expenseStructure = useMemo(() => buildExpenseStructure(txs, items), [txs, items]);
 
   const actualMap = useMemo(() => {
     const m = new Map();
@@ -89,12 +81,24 @@ export default function Dashboard({ items, totals, monthly, upsertBudget, actual
             <div className="h-full flex items-center justify-center text-gray-500">No data yet.</div>
           ) : (
             <ResponsiveContainer width="100%" height="100%">
-              <LineChart data={monthlySeries}>
+              <LineChart data={monthlySeries} margin={{ top: 60, right: 20, left: 40, bottom: 60 }}>
+                <defs>
+                  <linearGradient id="incomeFill" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#10B981" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#10B981" stopOpacity={0} />
+                  </linearGradient>
+                  <linearGradient id="expenseFill" x1="0" y1="0" x2="0" y2="1">
+                    <stop offset="5%" stopColor="#F43F5E" stopOpacity={0.3} />
+                    <stop offset="95%" stopColor="#F43F5E" stopOpacity={0} />
+                  </linearGradient>
+                </defs>
                 <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="label" />
+                <XAxis dataKey="label" interval={0} angle={-45} textAnchor="end" height={80} tickMargin={16} />
                 <YAxis tickFormatter={v=>fmtInt(v)} />
                 <Tooltip formatter={v=>fmtInt(v)} />
-                <Legend />
+                <Legend verticalAlign="top" height={36} />
+                <Area type="monotone" dataKey="income" stroke="none" fill="url(#incomeFill)" />
+                <Area type="monotone" dataKey="expense" stroke="none" fill="url(#expenseFill)" />
                 <Line type="monotone" dataKey="income" name="Income" stroke="#10B981" dot={false} strokeWidth={2} />
                 <Line type="monotone" dataKey="expense" name="Expense" stroke="#F43F5E" dot={false} strokeWidth={2} />
               </LineChart>
@@ -107,10 +111,28 @@ export default function Dashboard({ items, totals, monthly, upsertBudget, actual
           ) : (
             <ResponsiveContainer width="100%" height="100%">
               <PieChart>
-                <Pie data={expenseStructure} dataKey="share" nameKey="item" label={({item,share})=>`${item} — ${share}%`}>
-                  {expenseStructure.map(e => <Cell key={e.item} fill={colorFor(e.item)} />)}
+                <Pie
+                  data={expenseStructure}
+                  dataKey="share"
+                  nameKey="item"
+                  innerRadius={60}
+                  outerRadius={100}
+                  paddingAngle={2}
+                >
+                  {expenseStructure.map(e => (
+                    <Cell key={e.item} fill={colorFor(e.item)} />
+                  ))}
                 </Pie>
-                <Tooltip formatter={(v,name,props)=>fmtInt(props.payload.amount)} />
+                <Tooltip formatter={(v, name, props) => fmtInt(props.payload.amount)} />
+                <Legend
+                  layout="vertical"
+                  align="right"
+                  verticalAlign="middle"
+                  formatter={(value) => {
+                    const share = expenseStructure.find(e => e.item === value)?.share;
+                    return `${value} (${share}%)`;
+                  }}
+                />
               </PieChart>
             </ResponsiveContainer>
           )}


### PR DESCRIPTION
## Summary
- Reposition legend and expand line chart margins to avoid overlapping axis labels
- Base expense donut on yearly transactions using buildExpenseStructure and a new txs prop

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/recharts)*

------
https://chatgpt.com/codex/tasks/task_e_68a1d63cf780832f921b67d0be8bdd5f