### PR TITLE
Make dashboard charts resize responsively

### DIFF
--- a/src/Dashboard.jsx
+++ b/src/Dashboard.jsx
@@ -76,11 +76,11 @@ export default function Dashboard({ items, txs, totals, monthly, upsertBudget, a
       </div>
 
       <div className="grid gap-6 md:grid-cols-3">
-        <div className="h-[400px] rounded-2xl border bg-white p-4 shadow-sm md:col-span-2" aria-label="Monthly Income vs Expenses">
+        <div className="rounded-2xl border bg-white p-4 shadow-sm md:col-span-2" aria-label="Monthly Income vs Expenses">
           {monthlySeries.length === 0 ? (
-            <div className="h-full flex items-center justify-center text-gray-500">No data yet.</div>
+            <div className="min-h-[200px] flex items-center justify-center text-gray-500">No data yet.</div>
           ) : (
-            <ResponsiveContainer width="100%" height="100%">
+            <ResponsiveContainer width="100%" aspect={2}>
               <LineChart data={monthlySeries} margin={{ top: 60, right: 20, left: 40, bottom: 60 }}>
                 <defs>
                   <linearGradient id="incomeFill" x1="0" y1="0" x2="0" y2="1">
@@ -105,11 +105,11 @@ export default function Dashboard({ items, txs, totals, monthly, upsertBudget, a
             </ResponsiveContainer>
           )}
         </div>
-        <div className="h-[400px] rounded-2xl border bg-white p-4 shadow-sm md:col-span-1" aria-label="Expense Structure">
+        <div className="rounded-2xl border bg-white p-4 shadow-sm md:col-span-1" aria-label="Expense Structure">
           {expenseStructure.length === 0 ? (
-            <div className="h-full flex items-center justify-center text-gray-500">No data yet.</div>
+            <div className="min-h-[200px] flex items-center justify-center text-gray-500">No data yet.</div>
           ) : (
-            <ResponsiveContainer width="100%" height="100%">
+            <ResponsiveContainer width="100%" aspect={1}>
               <PieChart margin={{ bottom: 40 }}>
                 <Pie
                   data={expenseStructure}


### PR DESCRIPTION
## Summary
- Let line and pie chart cards size automatically instead of using fixed 400px height
- Use ResponsiveContainer aspect ratios and add minimal placeholders to prevent overlap and wasted space

## Testing
- `npm test` *(fails: Missing script "test" [no test suite])*
- `npm run build` *(fails: Cannot find module '@rollup/rollup-linux-x64-gnu'; `npm install` returns 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a3c7b6ee6c832fbba55b6d52079613